### PR TITLE
feat: `EmitStaticDelegateUnsafe` extension to il cursor for optimized anonymous delegate emission

### DIFF
--- a/src/modules/Daybreak.MonoMod/Extensions.EmitStaticDelegateUnsafe.cs
+++ b/src/modules/Daybreak.MonoMod/Extensions.EmitStaticDelegateUnsafe.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using MonoMod.Cil;
+
+namespace Daybreak.MonoMod;
+
+partial class Extensions
+{
+    extension(ILCursor c)
+    {
+        /// <summary>
+        ///     Emits the IL to invoke the <paramref name="delegate"/> as if it
+        ///     where a method.
+        ///     <br />
+        ///     <br />
+        ///     This is an optimized variant of
+        ///     <see cref="ILCursor.EmitDelegate"/> which is capable of lifting
+        ///     anonymous delegates into static functions, allowing for a direct
+        ///     <c>call</c> to the method without the overhead of virtualization
+        ///     or hanging onto a reference to the delegate target.
+        ///     <br />
+        ///     This method performs the IL emission slower than
+        ///     <see cref="ILCursor.EmitDelegate"/> in exchange for less
+        ///     overhead in the execution of the function itself.
+        ///     <br />
+        ///     <br />
+        ///     Validation of the emission is confirmed upon invocation of this
+        ///     API, meaning it will throw an exception if a reference to the
+        ///     <see langword="this"/> parameter of the
+        ///     <paramref name="delegate"/> is found.
+        ///     <br />
+        ///     <br />
+        ///     <b>
+        ///         Only use this function if you have marked your
+        ///         <paramref name="delegate"/> as <see langword="static"/>.
+        ///         Usage of this API will prevent breakpoints, hot reloading,
+        ///         and other debug functions from working within the scope of
+        ///         the delegate, as its body is cloned to a new method for
+        ///         emission.
+        ///     </b>
+        /// </summary>
+        /// <param name="delegate">
+        ///     The delegate to clone and emit a call to.
+        /// </param>
+        public void EmitStaticDelegateUnsafe(Delegate @delegate)
+        {
+        }
+    }
+}

--- a/src/modules/Daybreak.MonoMod/Extensions.EmitStaticDelegateUnsafe.cs
+++ b/src/modules/Daybreak.MonoMod/Extensions.EmitStaticDelegateUnsafe.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Mono.Cecil;
 using MonoMod.Cil;
+using MonoMod.Utils;
 
 namespace Daybreak.MonoMod;
 
@@ -9,7 +11,7 @@ partial class Extensions
     {
         /// <summary>
         ///     Emits the IL to invoke the <paramref name="delegate"/> as if it
-        ///     where a method.
+        ///     were a method.
         ///     <br />
         ///     <br />
         ///     This is an optimized variant of
@@ -43,6 +45,68 @@ partial class Extensions
         /// </param>
         public void EmitStaticDelegateUnsafe(Delegate @delegate)
         {
+            using var dmd = new DynamicMethodDefinition(@delegate.Method);
+            var method = dmd.Definition;
+
+            if (method is { HasThis: false, IsStatic: true })
+            {
+                // It's assumedly fine for this to be emitted directly?
+                c.EmitDelegate(@delegate);
+                return;
+            }
+
+            using (var methodCtx = new ILContext(method))
+            {
+                var methodCursor = new ILCursor(methodCtx);
+
+                // Convert raw argument-referencing opcodes to their Cecil
+                // "safe" variants.  MonoMod already resolves the raw index from
+                // "safe" variants, so remaking them here is fine.
+                while (true)
+                {
+                    var parameterIdx = -1;
+                    if (methodCursor.TryGotoNext(MoveType.Before, x => x.MatchLdarg(out parameterIdx)))
+                    {
+                        VerifyAndModifyInstruction(methodCursor, parameterIdx, methodCursor.EmitLdarg);
+                        continue;
+                    }
+
+                    if (methodCursor.TryGotoNext(MoveType.Before, x => x.MatchLdarga(out parameterIdx)))
+                    {
+                        VerifyAndModifyInstruction(methodCursor, parameterIdx, methodCursor.EmitLdarga);
+                        continue;
+                    }
+
+                    if (methodCursor.TryGotoNext(MoveType.Before, x => x.MatchStarg(out parameterIdx)))
+                    {
+                        VerifyAndModifyInstruction(methodCursor, parameterIdx, methodCursor.EmitStarg);
+                        continue;
+                    }
+
+                    break;
+                }
+            }
+
+            // Doesn't matter much where this happens as long as it's after
+            // we analyze and edit the method (and before we generate the
+            // new method, duh).
+            method.HasThis = false;
+            method.ExplicitThis = false;
+            method.IsStatic = true;
+
+            var compiled = dmd.Generate();
+            c.EmitCall(compiled);
         }
+    }
+
+    private static void VerifyAndModifyInstruction(ILCursor c, int parameterIndex, Func<ParameterDefinition, ILCursor> emitter)
+    {
+        if (parameterIndex == 0)
+        {
+            throw new InvalidOperationException("Cannot emit a static delegate that references the 'this' parameter.");
+        }
+
+        c.Remove();
+        emitter(c.Method.Parameters[parameterIndex]);
     }
 }


### PR DESCRIPTION
Introduces a new API, `EmitStaticDelegateUnsafe`, designed to lift non-capturing anonymous delegates to directly-invokable static methods, removing the overhead of delegate invocation.

This has been implemented during an ongoing rewrite and has not yet been tested, so this PR implemented the working draft.