### PR TITLE
feat: introduce new hook APIs

### DIFF
--- a/src/Daybreak.Hooks.V1/Daybreak.Hooks.V1.csproj
+++ b/src/Daybreak.Hooks.V1/Daybreak.Hooks.V1.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Tomat.Terraria.ModLoader.Sdk">
 
-    <Import Project="../Module.props"/>
+    <Import Project="../Module.props" />
 
     <ItemGroup>
-        <ProjectReference Include="..\Daybreak.EarlyLoader.V1\Daybreak.EarlyLoader.V1.csproj"/>
+        <ProjectReference Include="..\Daybreak.EarlyLoader.V1\Daybreak.EarlyLoader.V1.csproj" />
+        <ProjectReference Include="..\Daybreak.MonoMod.V1\Daybreak.MonoMod.V1.csproj" />
+        <ProjectReference Include="..\Daybreak.Rendering.V1\Daybreak.Rendering.V1.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Daybreak.Hooks.V1/Daybreak.Hooks.V1.csproj.DotSettings
+++ b/src/Daybreak.Hooks.V1/Daybreak.Hooks.V1.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=rendering/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=ui/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Daybreak.Hooks.V1/Rendering/RenderLayerHooks.cs
+++ b/src/Daybreak.Hooks.V1/Rendering/RenderLayerHooks.cs
@@ -1,0 +1,63 @@
+﻿using JetBrains.Annotations;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Daybreak.Rendering.V1;
+using Terraria;
+using Terraria.Graphics.Effects;
+using Terraria.ModLoader;
+
+namespace Daybreak.Hooks.V1;
+
+file delegate void RenderLayerDefinition(
+    [Omittable] SpriteBatch sb,
+    [Omittable] GraphicsDevice device
+);
+
+/// <summary>
+///     Automatically calls the decorated function before the associated <see cref="Overlay"/>s at the given layer.
+/// </summary>
+/// <param name="layer"></param>
+[MeansImplicitUse]
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+[HookMetadata(DelegateType = typeof(RenderLayerDefinition))]
+public sealed class RenderLayerAttribute(RenderLayers layer) : BaseHookAttribute
+{
+    public override void Apply(MethodInfo bindingMethod, object? instance)
+    {
+        var method = HookSubscriber.BuildWrapper<RenderLayerDefinition>(bindingMethod, instance);
+
+        RenderLayerRenderer.LAYERS.TryAdd(layer, []);
+        RenderLayerRenderer.LAYERS[layer].Add(method);
+    }
+}
+
+file static class RenderLayerRenderer
+{
+    public static readonly Dictionary<RenderLayers, List<RenderLayerDefinition>> LAYERS = [];
+
+    [OnLoad(Side = ModSide.Client)]
+    private static void Load()
+    {
+        On_OverlayManager.Draw += Draw_RenderLayers;
+        IL_Main.DoDraw += _ => { };
+        IL_Main.DoDraw_WallsAndBlacks += _ => { };
+    }
+
+    private static void Draw_RenderLayers(On_OverlayManager.orig_Draw orig, OverlayManager self, SpriteBatch sb, RenderLayers layer, bool beginSpriteBatch)
+    {
+        using (sb.Scope())
+        {
+            if (LAYERS.TryGetValue(layer, out var layers))
+            {
+                foreach (var renderLayer in layers)
+                {
+                    renderLayer(sb, Main.graphics.GraphicsDevice);
+                }
+            }
+        }
+
+        orig(self, sb, layer, beginSpriteBatch);
+    }
+}

--- a/src/Daybreak.Hooks.V1/Rendering/RenderLayerHooks.cs
+++ b/src/Daybreak.Hooks.V1/Rendering/RenderLayerHooks.cs
@@ -24,6 +24,7 @@ file delegate void RenderLayerDefinition(
 [HookMetadata(DelegateType = typeof(RenderLayerDefinition))]
 public sealed class RenderLayerAttribute(RenderLayers layer) : BaseHookAttribute
 {
+    /// <inheritdoc />
     public override void Apply(MethodInfo bindingMethod, object? instance)
     {
         var method = HookSubscriber.BuildWrapper<RenderLayerDefinition>(bindingMethod, instance);

--- a/src/Daybreak.Hooks.V1/Rendering/ScreenFilterHooks.cs
+++ b/src/Daybreak.Hooks.V1/Rendering/ScreenFilterHooks.cs
@@ -1,0 +1,173 @@
+﻿using JetBrains.Annotations;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoMod.Cil;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Daybreak.MonoMod.V1;
+using Terraria;
+using Terraria.Graphics.Effects;
+using Terraria.ModLoader;
+
+namespace Daybreak.Hooks.V1;
+
+file delegate bool ScreenFilterDefinition(
+    SpriteBatch sb,
+    GraphicsDevice device,
+    RenderTarget2D screen,
+    RenderTarget2D screenSwap,
+    [Omittable] Color color
+);
+
+/// <summary>
+///     Automatically applies the decorated function as a screen filter during <see cref="FilterManager.EndCapture(RenderTarget2D, RenderTarget2D, RenderTarget2D)"/>.<br/><br/>
+/// 
+///     <b>Arguments:</b>
+///     <list type="bullet">
+///         <item>
+///             <term>screen</term>
+///             <description>
+///                 <see cref="RenderTarget2D"/> containing the contents of the screen with all prior filters in the hierarchy applied.
+///             </description>
+///         </item>
+///         <item>
+///             <term>screenSwap</term>
+///             <description>
+///                 Empty* <see cref="RenderTarget2D"/>; final rendering should be drawn to this target if returning <see langword="true"/>.
+///             </description>
+///         </item>
+///         <item>
+///             <term>color</term>
+///             <description>
+///                 Equivalent to <see cref="Main.ColorOfTheSkies"/>, provided as vanilla screen filters pass this into draw calls,
+///                 notably the screen itself should not be colored by this value when drawn to <b>screenSwap</b>,
+///                 instead should be used for filter specific coloration.<br/>
+///             </description>
+///         </item>
+///     </list>
+///
+///     Return <see langword="true"/> to swap the targets, should be done if <b>screenSwap</b> has been drawn to before returning.
+/// </summary>
+/// <param name="priority">
+///     Where this filter will be drawn during vanilla filter application, will be run before the first vanilla filter of the priority.
+/// </param>
+[MeansImplicitUse]
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+[HookMetadata(DelegateType = typeof(ScreenFilterDefinition))]
+public sealed class ScreenFilterAttribute(EffectPriority priority) : SubscribesToAttribute
+{
+    public override void Apply(MethodInfo bindingMethod, object? instance)
+    {
+        var method = HookSubscriber.BuildWrapper<ScreenFilterDefinition>(bindingMethod, instance);
+
+        ScreenFilterRenderer.FILTERS_BY_PRIORITY.TryAdd(priority, []);
+        ScreenFilterRenderer.FILTERS_BY_PRIORITY[priority].Add(method);
+    }
+}
+
+file static class ScreenFilterRenderer
+{
+    public static readonly Dictionary<EffectPriority, List<ScreenFilterDefinition>> FILTERS_BY_PRIORITY = [];
+
+    [OnLoad(Side = ModSide.Client)]
+    private static void Load()
+    {
+        IL_FilterManager.EndCapture_RenderTarget2D_RenderTarget2D_RenderTarget2D_Vector2_Vector2_Vector2 += EndCapture_ScreenFilters;
+    }
+
+    [ModSystemHooks.RequiresScreenTarget]
+    private static bool RequiresScreenTarget() => true;
+
+    // TODO: See if this edit plays nicely stacked.
+    private static void EndCapture_ScreenFilters(ILContext il)
+    {
+        var c = new ILCursor(il);
+
+        var priorPriorityReference = c.AddVariable<EffectPriority?>();
+
+        var tIndex = VariableIndex.Invalid;
+        var t2Index = VariableIndex.Invalid;
+        var value2Index = VariableIndex.Invalid;
+
+        c.GotoNext(
+            MoveType.After,
+            i => i.MatchLdloca(out t2Index),
+            i => i.MatchLdloca(out tIndex),
+            i => i.MatchCall(typeof(Utils), nameof(Utils.Swap))
+        );
+
+        c.GotoNext(
+            MoveType.After,
+            i => i.MatchLdloc(out int _),
+            i => i.MatchCallvirt<LinkedListNode<Filter>>($"get_{nameof(LinkedListNode<>.Value)}"),
+            i => i.MatchStloc(out value2Index)
+        );
+
+        c.EmitLdloca((int)tIndex);
+        c.EmitLdloca((int)t2Index);
+
+        c.EmitLdloca(priorPriorityReference);
+
+        c.EmitLdloc((int)value2Index);
+        c.EmitCallvirt(
+            typeof(GameEffect).GetProperty(
+                nameof(GameEffect.Priority),
+                BindingFlags.Instance | BindingFlags.Public
+            )!.GetMethod!
+        );
+
+        c.EmitDelegate(ApplyFiltersToPriority);
+
+        // Run all remaining shaders if the VeryHigh priority was not reached
+        c.GotoNext(
+            MoveType.Before,
+            i => i.MatchLdloc(out int _),
+            i => i.MatchLdarg(out int _),
+            i => i.MatchCallvirt<GraphicsDevice>(nameof(GraphicsDevice.SetRenderTarget))
+        );
+
+        c.EmitLdloca((int)tIndex);
+        c.EmitLdloca((int)t2Index);
+
+        c.EmitLdloca(priorPriorityReference);
+        c.EmitLdcI4((int)EffectPriority.VeryHigh);
+
+        c.EmitDelegate(ApplyFiltersToPriority);
+    }
+
+    private static void ApplyFiltersToPriority(ref RenderTarget2D target, ref RenderTarget2D target2, ref EffectPriority? prior, EffectPriority nextPriority)
+    {
+        if (ModLoader.isLoading)
+        {
+            return;
+        }
+
+        if (prior != null
+         && prior == nextPriority)
+        {
+            return;
+        }
+
+        var color = Main.ColorOfTheSkies;
+
+        prior ??= EffectPriority.VeryLow;
+
+        for (var p = prior.Value; p <= nextPriority; p++)
+        {
+            if (!FILTERS_BY_PRIORITY.TryGetValue(p, out var filters))
+            {
+                continue;
+            }
+
+            foreach (var filter in filters)
+            {
+                if (filter(Main.spriteBatch, Main.graphics.GraphicsDevice, target, target2, color))
+                {
+                    Utils.Swap(ref target2, ref target);
+                }
+            }
+        }
+        prior = nextPriority;
+    }
+}

--- a/src/Daybreak.Hooks.V1/Rendering/ScreenFilterHooks.cs
+++ b/src/Daybreak.Hooks.V1/Rendering/ScreenFilterHooks.cs
@@ -57,6 +57,7 @@ file delegate bool ScreenFilterDefinition(
 [HookMetadata(DelegateType = typeof(ScreenFilterDefinition))]
 public sealed class ScreenFilterAttribute(EffectPriority priority) : SubscribesToAttribute
 {
+    /// <inheritdoc />
     public override void Apply(MethodInfo bindingMethod, object? instance)
     {
         var method = HookSubscriber.BuildWrapper<ScreenFilterDefinition>(bindingMethod, instance);

--- a/src/Daybreak.Hooks.V1/UI/GameInterfaceLayerHooks.cs
+++ b/src/Daybreak.Hooks.V1/UI/GameInterfaceLayerHooks.cs
@@ -1,0 +1,178 @@
+﻿using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Terraria.ModLoader;
+using Terraria.UI;
+
+namespace Daybreak.Hooks.V1;
+
+[Autoload(Side = ModSide.Client)]
+public static class GameInterfaceLayers
+{
+    public const string INTERFACE_LOGIC_1 = "Vanilla: Interface Logic 1";
+    public const string MP_PLAYER_NAMES = "Vanilla: MP Player Names";
+    public const string EMOTE_BUBBLES = "Vanilla: Emote Bubbles";
+    public const string ENTITY_MARKERS = "Vanilla: Entity Markers";
+    public const string SMART_CURSOR_TARGETS = "Vanilla: Smart Cursor Targets";
+    public const string LASER_RULER = "Vanilla: Laser Ruler";
+    public const string RULER = "Vanilla: Ruler";
+    public const string GAMEPAD_LOCK_ON = "Vanilla: Gamepad Lock On";
+    public const string TILE_GRID_OPTION = "Vanilla: Tile Grid Option";
+    public const string TOWN_NPC_HOUSE_BANNERS = "Vanilla: Town NPC House Banners";
+    public const string HIDE_UI_TOGGLE = "Vanilla: Hide UI Toggle";
+    public const string WIRE_SELECTION = "Vanilla: Wire Selection";
+    public const string CAPTURE_MANAGER_CHECK = "Vanilla: Capture Manager Check";
+    public const string IN_GAME_OPTIONS = "Vanilla: Ingame Options";
+    public const string FANCY_UI = "Vanilla: Fancy UI";
+    public const string ACHIEVEMENT_COMPLETE_POPUPS = "Vanilla: Achievement Complete Popups";
+    public const string ENTITY_HEALTH_BARS = "Vanilla: Entity Health Bars";
+    public const string INVASION_PROGRESS_BARS = "Vanilla: Invasion Progress Bars";
+    public const string MAP_MINIMAP = "Vanilla: Map / Minimap";
+    public const string DIAGNOSE_NET = "Vanilla: Diagnose Net";
+    public const string SIGN_TILE_BUBBLE = "Vanilla: Sign Tile Bubble";
+    public const string HAIR_WINDOW = "Vanilla: Hair Window";
+    public const string DRESSER_WINDOW = "Vanilla: Dresser Window";
+    public const string NPC_SIGN_DIALOG = "Vanilla: NPC / Sign Dialog";
+    public const string INTERFACE_LOGIC_2 = "Vanilla: Interface Logic 2";
+    public const string RESOURCE_BARS = "Vanilla: Resource Bars";
+    public const string INTERFACE_LOGIC_3 = "Vanilla: Interface Logic 3";
+    public const string INVENTORY = "Vanilla: Inventory";
+    public const string INFO_ACCESSORIES_BAR = "Vanilla: Info Accessories Bar";
+    public const string SETTINGS_BUTTON = "Vanilla: Settings Button";
+    public const string CONTROL_HINTS = "Vanilla: Control Hints";
+    public const string HOTBAR = "Vanilla: Hotbar";
+    public const string BUILDER_ACCESSORIES_BAR = "Vanilla: Builder Accessories Bar";
+    public const string RADIAL_HOTBARS = "Vanilla: Radial Hotbars";
+    public const string MOUSE_TEXT = "Vanilla: Mouse Text";
+    public const string PLAYER_CHAT = "Vanilla: Player Chat";
+    public const string DEATH_TEXT = "Vanilla: Death Text";
+    public const string CURSOR = "Vanilla: Cursor";
+    public const string DEBUG_STUFF = "Vanilla: Debug Stuff";
+    public const string MOUSE_ITEM_NPC_HEAD = "Vanilla: Mouse Item / NPC Head";
+    public const string MOUSE_OVER = "Vanilla: Mouse Over";
+    public const string INTERACT_ITEM_ICON = "Vanilla: Interact Item Icon";
+    public const string INTERFACE_LOGIC_4 = "Vanilla: Interface Logic 4";
+
+    [AttributeUsage(AttributeTargets.ReturnValue)]
+    private sealed class PermitsVoidWithTrueAttribute : AbstractPermitsVoidAttribute
+    {
+        public override Expression ModifyExpression(HookSubscriber.ReturnExpressionContext ctx)
+        {
+            return Expression.Block(ctx.CallExpression, Expression.Constant(true));
+        }
+    }
+
+    // Identical to GameInterfaceDrawMethod
+    /// <returns>
+    ///     <see langword="false"/> to stop all further <see cref="GameInterfaceLayer"/>s from drawing (permits <see langword="void"/>.)
+    /// </returns>
+    [return: PermitsVoidWithTrue]
+    private delegate bool InterfaceDrawDefinition();
+
+    /// <summary>
+    ///     Inserts the decorated method as a <see cref="GameInterfaceLayer"/> before/after the target layer.<br/>
+    /// </summary>
+    /// <param name="targetLayer">
+    ///     Name of the target <see cref="GameInterfaceLayer"/>, constants are provided for vanilla layers in <see cref="GameInterfaceLayers"/>.
+    /// </param>
+    /// <param name="scaleType">
+    ///     Changes how the cursor/screen is scaled, along with what matrix is used in the given active SpriteBatch.
+    /// </param>
+    /// <inheritdoc cref="InterfaceDrawDefinition" />
+    [MeansImplicitUse]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    [HookMetadata(DelegateType = typeof(InterfaceDrawDefinition))]
+    public class InsertAttribute(string targetLayer, InterfaceScaleType scaleType, bool after) : BaseHookAttribute
+    {
+        /// <summary>
+        ///     Name of the target <see cref="GameInterfaceLayer"/>, constants are provided for vanilla layers in <see cref="GameInterfaceLayers"/>.
+        /// </summary>
+        public readonly string TargetLayer = targetLayer;
+
+        /// <summary>
+        ///     Changes how the cursor/screen is scaled, along with what matrix is used in the given active SpriteBatch.
+        /// </summary>
+        public readonly InterfaceScaleType ScaleType = scaleType;
+
+        public readonly bool After = after;
+
+        /// <summary>
+        ///     Identifier of this layer, usually <c>"ModName: UIName"</c>,
+        ///     leave <see langword="null"/> to use default identifier based on <c>"AssemblyName: MethodName"</c>.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <inheritdoc />
+        public override void Apply(MethodInfo bindingMethod, object? instance)
+        {
+            // TODO: More formal generated names?
+            var name = Name ?? $"{bindingMethod.DeclaringType!.Assembly.GetName().Name}: {bindingMethod.Name}";
+
+            var method = new GameInterfaceDrawMethod(HookSubscriber.BuildWrapper<InterfaceDrawDefinition>(bindingMethod, instance));
+
+            var interfaceLayer = new LegacyGameInterfaceLayer(
+                name,
+                method,
+                ScaleType
+            );
+
+            layers.Add(
+                new Layer(
+                    interfaceLayer,
+                    TargetLayer,
+                    After
+                )
+            );
+        }
+    }
+
+    /// <summary>
+    ///     Inserts the decorated method as a <see cref="GameInterfaceLayer"/> before the target layer.
+    /// </summary>
+    /// <inheritdoc cref="InsertAttribute"/>
+    [MeansImplicitUse]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    [HookMetadata(DelegateType = typeof(InterfaceDrawDefinition))]
+    public sealed class BeforeAttribute(string targetLayer, InterfaceScaleType scaleType)
+        : InsertAttribute(targetLayer, scaleType, false);
+
+    /// <summary>
+    ///     Inserts the decorated method as a <see cref="GameInterfaceLayer"/> after the target layer.
+    /// </summary>
+    /// <inheritdoc cref="InsertAttribute"/>
+    [MeansImplicitUse]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    [HookMetadata(DelegateType = typeof(InterfaceDrawDefinition))]
+    public sealed class AfterAttribute(string targetLayer, InterfaceScaleType scaleType)
+        : InsertAttribute(targetLayer, scaleType, true);
+
+    private record struct Layer(LegacyGameInterfaceLayer InterfaceLayer, string TargetLayer, bool After);
+
+    private static readonly HashSet<Layer> layers = [];
+
+    [ModSystemHooks.ModifyInterfaceLayers]
+    private static void ModifyInterfaceLayers([OriginalName("layers")] List<GameInterfaceLayer> interfaceLayers)
+    {
+        foreach (var layer in layers)
+        {
+            var index = interfaceLayers.FindIndex(l => l.Name.Equals(layer.TargetLayer));
+
+            if (index <= -1)
+            {
+                continue;
+            }
+
+            if (layer.After)
+            {
+                index++;
+            }
+
+            interfaceLayers.Insert(
+                index,
+                layer.InterfaceLayer
+            );
+        }
+    }
+}


### PR DESCRIPTION
Port of my less opinionated hooks from Rosemary [here](https://github.com/swirlier-ink/rosemary/blob/main/src/Rosemary/Common/Hooks/GameInterfaceLayerHooks.cs).

## Includes:
- `GameInterfaceLayers` with `Before` and `After` which effectively wraps TML's `ModifyInterfaceLayers`, provides constants for every vanilla layer.
- `ScreenFilter` which provides an alternative screen filter API that bypasses all the boilerplate of vanilla filters and allows you to mutate the screen targets however you want. (The edit used may not be stackable (although it likely is,) unsure how to handle this.)
- `RenderLayer` which draws the target method below overlays at the target `RenderLayers`.

## Notes:
- At the minute `ScreenFilter` will only render its effects below all vanilla filters of that priority, should this be changed? Additionally would a way to sort before/after specific vanilla filters be useful?